### PR TITLE
Updated pagination code for timelines

### DIFF
--- a/src/byota/mastodon.py
+++ b/src/byota/mastodon.py
@@ -54,7 +54,6 @@ def get_paginated_data(
                 print("No more pages available.")
                 break
 
-
     return paginated_data
 
 


### PR DESCRIPTION
# What's changing

Fixing the code in paginated download of timelines so it works with the latest Mastodon.py update.

Refs #1 
Closes #1 

# How to test it

Run with any timeline that has fewer than the default amount of pages (40)
