### PR TITLE
Honor discoverable field

### DIFF
--- a/src/byota/mastodon.py
+++ b/src/byota/mastodon.py
@@ -105,7 +105,9 @@ def get_paginated_statuses(
     return paginated_data
 
 
-def get_compact_data(paginated_data: list) -> list[tuple[int, str]]:
+def get_compact_data(
+    paginated_data: list, honor_discoverable: bool = True
+) -> list[tuple[int, str]]:
     """
     Extract compact (id, text) pairs from a paginated list of statuses.
     Honor the author's `discoverable` tag and add the status only if the
@@ -116,7 +118,7 @@ def get_compact_data(paginated_data: list) -> list[tuple[int, str]]:
     for page in paginated_data:
         for toot in page:
             # skip the post if the account has discoverable == False
-            if not toot.account.discoverable:
+            if honor_discoverable and not toot.account.discoverable:
                 continue
             id = toot.id
             cont = toot.content

--- a/src/demo.py
+++ b/src/demo.py
@@ -570,7 +570,7 @@ def _(mo):
 
 
 @app.cell
-def _(BeautifulSoup, EmbeddingService, mo, pickle, time):
+def _(EmbeddingService, mo, pickle, time):
     def load_dataframes(data_file):
         dataframes = None
         print(f"Loading cached dataframes from {data_file}")
@@ -618,27 +618,7 @@ def _(BeautifulSoup, EmbeddingService, mo, pickle, time):
 
         return embeddings
 
-    def get_compact_data(paginated_data: list) -> list[tuple[int, str]]:
-        """Extract compact (id, text) pairs from a paginated list of statuses."""
-        compact_data = []
-        for page in paginated_data:
-            for toot in page:
-                id = toot.id
-                cont = toot.content
-                if toot.reblog:
-                    id = toot.reblog.id
-                    cont = toot.reblog.content
-                soup = BeautifulSoup(cont, features="html.parser")
-                # print(f"{id}: {soup.get_text()}")
-                compact_data.append((id, soup.get_text()))
-        return compact_data
-
-    return build_cache_embeddings, get_compact_data, load_dataframes
-
-
-@app.cell
-def _():
-    return
+    return build_cache_embeddings, load_dataframes
 
 
 if __name__ == "__main__":

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,18 @@
+import json
+import pytest
+
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    with Path.open(path) as file:
+        return json.load(file)
+
+
+def resources_dir() -> Path:
+    return Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="session")
+def paginated_data() -> dict:
+    return load_json(resources_dir() / "mastodon_data.json")

--- a/tests/unit/data/mastodon_data.json
+++ b/tests/unit/data/mastodon_data.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": "123456789012345678",
+        "account": {
+            "id": "12345",
+            "discoverable": true
+        },
+        "reblog": {
+            "id": "123456789012345679",
+            "content": "This is a reblogged status from a discoverable account"
+        },
+        "content": ""
+    },
+    {
+        "id": "123456789012345679",
+        "account": {
+            "id": "54321",
+            "discoverable": false
+        },
+        "content": "This is a status from a non-discoverable account"
+    }
+]

--- a/tests/unit/test_mastodon.py
+++ b/tests/unit/test_mastodon.py
@@ -1,0 +1,23 @@
+import mastodon.return_types
+import mastodon.types_base
+from byota.mastodon import get_compact_data
+import mastodon
+
+
+def test_get_compact_data(paginated_data):
+    # generate a list of mastodon Status objects from the test json file
+    status_list = []
+    for masto_status in paginated_data:
+        status_list.append(
+            mastodon.types_base.try_cast_recurse(
+                mastodon.return_types.Status, masto_status
+            )
+        )
+
+    # get compact data honoring the discoverability tag (we expect 1 status)
+    compact_data = get_compact_data([status_list])
+    assert len(compact_data) == 1
+
+    # get compact data without honoring the discoverability tag (we expect 2 statuses)
+    compact_data = get_compact_data([status_list], honor_discoverable=False)
+    assert len(compact_data) == 2


### PR DESCRIPTION
Added a few changes to honor the discoverable field in Mastodon accounts:

- `get_compact_data` is moved to `mastodon.py` and upated to skip those statuses where `account.discoverable` is False
- `notebook.py` is updated to look for the method inside `mastodon.py`
- `demo.py` is updated to remove the method (which was not used anyway, as we are not using paginated data but directly loading dataframes)
- added unit test

# What's changing

Closes #11 

# How to test it

Run the notebook, and verify the absence of accounts you know have the discoverable status = False.
As a quicker (albeit more superficial) check, the total number of posts per timeline will be smaller than
the default (which is 20 posts * 40 pages = 800 posts).

# Additional notes for reviewers

I guess this is not needed for accounts directly followed by the user running the code (in this case the
posts and the account are already visible, so there's nothing to discover). I decided to be conservative
though and will address this as a separate issue (tentatively, we could set the `honor_discoverable`
parameter in `get_compact_data` to False for the home timeline, but I'd like to discuss this publicly first).

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [x] Updated the documentation (comments in code)
