### PR TITLE
Update demo UI to always use llamafile

### DIFF
--- a/src/byota/layout.py
+++ b/src/byota/layout.py
@@ -15,12 +15,17 @@ def invalid_form(form):
     return False
 
 
-def create_configuration_form(accounts: list[MastodonAccount]):
+def create_configuration_form(
+    accounts: list[MastodonAccount], include_embedding_config: bool = True
+):
     """
     Create a dynamic configuration form based on the loaded accounts.
 
     Args:
         accounts: list of MastodonAccount objects
+        include_embedding_config: whether to expose the embedding server
+            fields (server type, URL, model). Set to False for the demo,
+            where the embedding server is fixed to the bundled llamafile.
 
     Returns:
         Marimo form object
@@ -46,24 +51,35 @@ def create_configuration_form(accounts: list[MastodonAccount]):
         batch_dict[f"tl_{account_name}_list_txt"] = mo.ui.text()
 
     # Add the non-timeline fields
-    batch_dict.update(
-        {
-            "emb_server": mo.ui.radio(
-                label="Server type:",
-                options=["llamafile", "ollama"],
-                value="llamafile",
-                inline=True,
-            ),
-            "emb_server_url": mo.ui.text(
-                label="Embedding server URL:",
-                value="http://localhost:8080/embedding",
-                full_width=True,
-            ),
-            "emb_server_model": mo.ui.text(
-                label="Embedding server model:", value="all-minilm"
-            ),
-            "offline_mode": mo.ui.checkbox(label="Run in offline mode (experimental)"),
-        }
+    embeddings_section = ""
+    if include_embedding_config:
+        batch_dict.update(
+            {
+                "emb_server": mo.ui.radio(
+                    label="Server type:",
+                    options=["llamafile", "ollama"],
+                    value="llamafile",
+                    inline=True,
+                ),
+                "emb_server_url": mo.ui.text(
+                    label="Embedding server URL:",
+                    value="http://localhost:8080/embedding",
+                    full_width=True,
+                ),
+                "emb_server_model": mo.ui.text(
+                    label="Embedding server model:", value="all-minilm"
+                ),
+            }
+        )
+        embeddings_section = (
+            "**Embeddings**\n\n"
+            "{emb_server}\n\n"
+            "{emb_server_url}\n\n"
+            "{emb_server_model}"
+        )
+
+    batch_dict["offline_mode"] = mo.ui.checkbox(
+        label="Run in offline mode (experimental)"
     )
 
     # Create the form
@@ -73,13 +89,8 @@ def create_configuration_form(accounts: list[MastodonAccount]):
 
 **Timelines**
 {timelines_section}
-**Embeddings**
 
-{{emb_server}}
-
-{{emb_server_url}}
-
-{{emb_server_model}}
+{embeddings_section}
 
 **Caching**
 

--- a/src/demo.py
+++ b/src/demo.py
@@ -77,7 +77,9 @@ def _(mo):
 
 @app.cell
 def _(config, layout):
-    configuration_form = layout.create_configuration_form(config.mock_account_list())
+    configuration_form = layout.create_configuration_form(
+        config.mock_account_list(), include_embedding_config=False
+    )
     configuration_form
     return (configuration_form,)
 
@@ -97,6 +99,7 @@ def _(
         mo.md("**Submit the form to continue.**").center(),
     )
 
+    # the demo always uses the bundled llamafile embedding server
     embedding_service = LLamafileEmbeddingService("http://localhost:8080/embedding")
 
     mo.stop(


### PR DESCRIPTION
# What's changing

The demo.py notebook is hardwired to call llamafile, but issue #22 raises the fact that the UI shows the possibility to select ollama as an alternative embedding service. This causes confusion and a different expected behavior.

As the purpose of the demo is to run everything without the need to install extra dependencies, we decided to keep llamafile hardwired and just remove the ollama option from the UI.

> If this PR is related to an issue or closes one, please link it here.

Closes #22 

# How to test it

Run demo.py, the UI now looks like this:

<img width="1149" height="667" alt="image" src="https://github.com/user-attachments/assets/9f56461e-6d4d-4b88-9f2d-cd09d014d16d" />

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
